### PR TITLE
Fixing Warning on HHVM

### DIFF
--- a/lib/W3/Plugin/TotalCache.php
+++ b/lib/W3/Plugin/TotalCache.php
@@ -509,7 +509,7 @@ class W3_Plugin_TotalCache extends W3_Plugin {
      * @param string $buffer
      * @return string
      */
-    function ob_callback(&$buffer) {
+    function ob_callback($buffer) {
         global $wpdb;
 
         if ($buffer != '') {


### PR DESCRIPTION
\nWarning: Parameter 1 to W3_Plugin_TotalCache::ob_callback() expected to be a reference, value given in /wp-includes/functions.php on line 3269
